### PR TITLE
Address page faults in source coverage collection

### DIFF
--- a/vendor/bochs/cpu/paging.cc
+++ b/vendor/bochs/cpu/paging.cc
@@ -839,12 +839,6 @@ bx_phy_address BX_CPU_C::translate_linear_long_mode(bx_address laddr, Bit32u &lp
       page_fault(ERROR_PROTECTION, laddr, user, rw);
   }
 
-  // SMAP protections are disabled if EFLAGS.AC=1
-  if (BX_CPU_THIS_PTR cr4.get_SMAP() && ! BX_CPU_THIS_PTR get_AC() && rw != BX_EXECUTE && ! user) {
-    if (combined_access & BX_COMBINED_ACCESS_USER)
-      page_fault(ERROR_PROTECTION, laddr, user, rw);
-  }
-
   if (BX_CPU_THIS_PTR cr4.get_PGE())
     combined_access |= (entry[leaf] & BX_COMBINED_GLOBAL_PAGE);
 


### PR DESCRIPTION
The page fault has two reasons: 

1. SMAP protection enabled. I can workaround by disabling this protection.
2. PTE not presented. Some pages of __llvm_prf_cnts sections do not have corresponding physical pages. I don't know why.

To address them: 
1. running L2, attach it using gdb and call (int)mlockall(3), then detach
2. patch to disable the check of SMAP in vendor/bochs/cpu/paging.cc:842
3. re-create the snapshot

Steps and patches are updated into README and vendor/bochs/cpu/paging.cc:842